### PR TITLE
Make image return inline when requested from hipchat

### DIFF
--- a/scripts/orly.coffee
+++ b/scripts/orly.coffee
@@ -16,11 +16,13 @@ module.exports = (robot) ->
     guideText = encodeURIComponent(msg.match[2].trim())
     topText = encodeURIComponent(msg.match[3].trim())
     author = encodeURIComponent(msg.match[4].trim())
-    
+
     # Animal range is from 1 to 40
     animal = Math.floor(Math.random() * 40) + 1;
-    
+
     # Color range is from 0 to 16
     color = Math.floor(Math.random() * 17);
-
-    msg.send "https://orly-appstore.herokuapp.com/generate?title=#{title}&guide_text=#{guideText}&top_text=#{topText}&author=#{author}&image_code=#{animal}&theme=#{color}"
+    if msg.robot.adapterName == 'hipchat'
+      msg.send "https://orly-appstore.herokuapp.com/generate?title=#{title}&guide_text=#{guideText}&top_text=#{topText}&author=#{author}&image_code=#{animal}&theme=#{color}&.png"
+    else
+      msg.send "https://orly-appstore.herokuapp.com/generate?title=#{title}&guide_text=#{guideText}&top_text=#{topText}&author=#{author}&image_code=#{animal}&theme=#{color}"


### PR DESCRIPTION
Previously, the response from the orly instruction would return a link.
While this is all well and good, people had to click things to see it.
This change simply appends a &.png suffix on the link returned, which
means that hipchat will render the image right in the chat window.

Signed-off-by: Michael Stahnke <stahnma@puppet.com>